### PR TITLE
Add Cacti syslog support

### DIFF
--- a/snmptt/contrib/README
+++ b/snmptt/contrib/README
@@ -7,4 +7,5 @@ These files are NOT supported and are meant to be used on a 'WYSIWYG' basis.
 
 FILE			DESCRIPTION
 ==============================================================================
-sendemail.sh		A script to send emails for the EXEC line
+sendemail.sh		   A script to send emails for the EXEC line
+cacti-syslog-connector.py  A script to connect SNMPTT to the Cacti Syslog plugin

--- a/snmptt/contrib/cacti-syslog-connector.py
+++ b/snmptt/contrib/cacti-syslog-connector.py
@@ -1,4 +1,9 @@
 
+#### Create by Sean Mancini sean@seanmancini.com www.seanmancini.com
+### usage enter  /opt/snmptt_syslog.py --hostname $aA --alert "$Fz" --priority 6 --facility 2  in your cacti syslog command execution 
+## this will write the messege direct to the cacti syslog incoming table to be ingested into the syslog database
+
+
 #!/usr/bin/python3
 
 ### connect to mysql database

--- a/snmptt/contrib/cacti-syslog-connector.py
+++ b/snmptt/contrib/cacti-syslog-connector.py
@@ -1,0 +1,60 @@
+
+#!/usr/bin/python3
+
+### connect to mysql database
+
+### import modules
+import mysql.connector
+import sys
+from datetime import datetime
+import argparse
+
+
+# Define Arguments for variables from snmptt
+parser = argparse.ArgumentParser(description = 'SNMPTT Variables')
+
+parser.add_argument('--hostname', help = "Device Hostname", required=True)
+parser.add_argument('--alert', help = "Alert Messege", required=True)
+parser.add_argument('--facility', help = "Alert Facility", required=True)
+parser.add_argument('--priority', help = "Alert Priority", required=True)
+
+
+
+args = parser.parse_args(sys.argv[1:])
+
+if args.hostname is not None: ({'device Hostname': args.hostname}) #snmp timeout
+if args.alert is not None: ({'Alert Messege': args.alert}) #device template
+if args.facility is not None: ({'Alert facility': args.facility}) #device template
+if args.priority is not None: ({'Alert priority': args.priority}) #device template
+
+
+
+### connect to database
+try:
+    db = mysql.connector.connect(
+        host = "localhost",
+        user = "",
+        passwd = "",
+        database = ""
+    )
+
+    ### create cursor
+    cursor = db.cursor()
+
+    ### write to database
+    sql = "INSERT INTO syslog_incoming (facility_id, priority_id, program, logtime, host, message) VALUES (%s, %s, %s, %s ,%s, %s)"
+    val = (args.facility,args.priority, "traps", datetime.now(),args.hostname, args.alert)
+    cursor.execute(sql, val)
+
+    ### commit changes
+    db.commit()
+
+    ### close database
+    db.close()
+
+    ### print success message
+    print("Successfully wrote to database")
+except:
+    ### print error message
+    print("Unable to write to database")
+    sys.exit(1)


### PR DESCRIPTION
Add script to connect SNMPTT to the cacti syslog plugin to provide hostname information of the original sender of the trap using SNMPTT variable substitution as an input 