### PR TITLE
Fix TRAP-TYPE / NOTIFICATION-TYPE detection

### DIFF
--- a/snmptt/snmpttconvertmib
+++ b/snmptt/snmpttconvertmib
@@ -479,7 +479,7 @@ if (1)
         print "Split line TRAP-TYPE / NOTIFICATION-TYPE found ($1).\n";
       }
       
-      # If the TRAP-TYPE / NOTIFICATION-TYPE line starts with white space, it's probably a import line, so ignore
+      # If the TRAP-TYPE / NOTIFICATION-TYPE line starts with white space, it's probably an import line, so ignore
       elsif ( $line =~ /^\s+TRAP-TYPE.*/ ||
            $line =~ /^\s+NOTIFICATION-TYPE.*/  ||
            $line =~ /^.*,.*NOTIFICATION-TYPE.*/ )
@@ -490,6 +490,16 @@ if (1)
         next;
       }
       
+      # If multiple words exists before TRAP-TYPE / NOTIFICATION-TYPE, it's probably a comment line, so ignore
+      elsif ( $line =~ /\S+\s+\S+\s+TRAP-TYPE.*/ ||
+           $line =~ /\S+\s+\S+\s+NOTIFICATION-TYPE.*/ )
+      {
+        print "skipping a TRAP-TYPE / NOTIFICATION-TYPE line - probably a comment line.\n";
+        $currentline++; # Increment to the next line
+        $line = $mibfile[$currentline]; # Get next line
+        next;
+      }
+
       # Remove beginning and trailing white space
       $trapname =~ /\s*([A-Za-z0-9_-]+)\s*/;
       $trapname = $1;


### PR DESCRIPTION
If multiple words exists before TRAP-TYPE / NOTIFICATION-TYPE, it's probably a comment line, so ignore.

Example: `tmnxCardFailOnError` found in https://www.circitor.fr/Mibs/Mib/T/TIMETRA-CHASSIS-MIB.mib 

```
tmnxCardFailOnError              OBJECT-TYPE
   SYNTAX       BITS {
                   memoryEventGroupA (0)
                }
   MAX-ACCESS   read-write
   STATUS       current
   DESCRIPTION
       "The value of tmnxCardFailOnError specifies the set of events that, if
        triggered, will cause the card to fail. The suppression or generation
        of the NOTIFICATION-TYPE event is independent of the card failing.
        The following set of events are configurable:
             memoryEventGroupA (0) - tmnxEqCardPChipMemoryEvent,
                                     tmnxEqCardPChipCamEvent,
                                     tmnxEqCardPChipError.
        tmnxEqCardPChipError will only cause a card failure if all MDAs(s)
        on the complex are Ethernet or ISAs."
   DEFVAL { {} }
   ::= { tmnxCardEntry 36 }
```