### PR TITLE
Update snmptt to add file locking support

### DIFF
--- a/snmptt/snmptt
+++ b/snmptt/snmptt
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# SNMPTT 1.5
+# SNMPTT 1.5.1beta1
 #
 # Copyright 2002-2022 Alex Burger
 # alex_b@users.sourceforge.net
@@ -48,7 +48,7 @@
 use strict;
 use warnings;
 
-my $snmptt_version = "1.5";
+my $snmptt_version = "1.5.1beta1";
 
 sub showversion
 {
@@ -169,6 +169,7 @@ my $snmptt_system_name;
 #my $daemon;
 my $multiple_event;
 my $dns_enable;
+my $dns_normalise_case;
 my $strip_domain;
 my @strip_domain_list;
 my $net_snmp_perl_enable;
@@ -194,8 +195,10 @@ my $ipv6_enable;
 my $date_format;
 my $time_format;
 my $date_time_format;
+my $date_time_utc;
 my $date_time_format_sql;
 my $stat_time_format_sql;
+my $date_time_utc_sql;
 
 # DaemonMode
 my $daemon_fork;
@@ -303,6 +306,7 @@ my $sql_win32_odbc_password;
 
 my @sql_custom_columns;
 my @sql_custom_columns_unknown;
+my @sql_custom_columns_statistics;
 
 # TrapFiles
 my @snmptt_conf_files;
@@ -317,7 +321,7 @@ loadsnmpttini();
 
 ##############################################################################
 #
-#  File Locking
+#  File locking
 #
 
 my $locking_method = 0;
@@ -348,6 +352,7 @@ sub acquire_lock {
 }
 
 ###############################################################################
+
 use Text::ParseWords;
 use POSIX qw(strftime);
 use Sys::Hostname;
@@ -379,7 +384,7 @@ if ($DEBUGGING >= 1)
   }
 
   # print out time
-  print "********** SNMPTT $snmptt_version started: ",scalar(localtime($g_start_time))," **********\n\n";
+  print "********** SNMPTT $snmptt_version started: ",scalar(get_time($g_start_time))," **********\n\n";
   if ($sleep < 1) {
     print "Note: snmptt.ini sleep setting is less than 1 so \'Sleeping for x seconds\' will be supressed in the debug log.\n\n";
   }
@@ -787,11 +792,17 @@ if ($daemon == 1)
     }
   }
 
-  $SIG{HUP} = \&signal_handler_reload;
+  if (exists ($SIG{HUP})) {
+    $SIG{HUP} = \&signal_handler_reload;
+  }
 
-  $SIG{TERM} = \&signal_handler_die;
+  if (exists ($SIG{TERM})) {
+    $SIG{TERM} = \&signal_handler_die;
+  }
 
-  $SIG{USR1} = \&signal_log_statistics;
+  if (exists ($SIG{USR1})) {
+    $SIG{USR1} = \&signal_log_statistics;
+  }
 
   $timetoreload = 0;
   $timetodie = 0;
@@ -1048,9 +1059,11 @@ if ($daemon == 1)
 
 
       if ($DEBUGGING >= 1) {
-        print $fh_DEBUGFILE "Closing debug file $DEBUGGING_FILE\n";
-        # Close debug file (if it is open) before changing users and re-open after
-        close($fh_DEBUGFILE);
+        if (defined ($fh_DEBUGFILE)) {
+          print $fh_DEBUGFILE "Closing debug file $DEBUGGING_FILE\n";
+          # Close debug file (if it is open) before changing users and re-open after
+          close($fh_DEBUGFILE);
+        }
       }
 	  
 	    # Change owner of debug file so $daemon_uid can write to it.
@@ -1116,7 +1129,7 @@ if ($daemon == 1)
       my $duplicate_traps_current_time = time();
       foreach my $key (sort keys %duplicate_traps)
       {
-        #print "Previous trap digest: $key: " . localtime($duplicate_traps{$key}) . "\n";
+        #print "Previous trap digest: $key: " . get_time($duplicate_traps{$key}) . "\n";
         if ($duplicate_traps{$key} < $duplicate_traps_current_time - $duplicate_trap_window) {
           # Purge the record
           delete $duplicate_traps{$key};
@@ -1309,8 +1322,7 @@ if ($daemon == 1)
 
           $filesuccess = 0;
         }
-
-
+        
         my $lock_status = acquire_lock($fh_FILE, 5);
         if ($lock_status == 0) {
           if ($DEBUGGING >= 1)
@@ -1319,6 +1331,7 @@ if ($daemon == 1)
           }
           warn "Could not acquire flock read lock\n";
         }
+        
 
         $input = $fh_FILE;
 
@@ -1454,7 +1467,7 @@ if ($daemon == 1)
 
   if ($DEBUGGING >= 1)
   {
-    print "SNMPTT $snmptt_version shutdown: ",scalar(localtime),"\n\n";
+    print "SNMPTT $snmptt_version shutdown: ",scalar(get_time()),"\n\n";
     print "Total traps received:    $g_total_traps_received\n";
     print "Total traps translated:  $g_total_traps_translated\n";
     print "Total traps ignored:     $g_total_traps_ignored\n";
@@ -2146,9 +2159,13 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              print "Performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Performing substitution on custom column: $_\n";
+              }
               substitute();
-              print "Done performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Done performing substitution on custom column: $_\n";
+              }
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2191,9 +2208,13 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              print "Performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Performing substitution on custom column: $_\n";
+              }
               substitute();
-              print "Done performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Done performing substitution on custom column: $_\n";
+              }
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2234,9 +2255,13 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              print "Performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Performing substitution on custom column: $_\n";
+              }
               substitute();
-              print "Done performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Done performing substitution on custom column: $_\n";
+              }
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2277,9 +2302,13 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              print "Performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Performing substitution on custom column: $_\n";
+              }
               substitute();
-              print "Done performing substitution on custom column: $_\n";
+              if ($DEBUGGING >= 1) {
+                print "Done performing substitution on custom column: $_\n";
+              }                
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2399,6 +2428,33 @@ sub processtrap
   } #while defined..
 }
 
+sub substitute_sql_stat
+{
+  my $format_line = shift;      # Used for $Fz variable substitution for EXEC line.
+
+  # $H - Host name of the system running SNMPTT
+  substitute2 ("\$H", $snmptt_system_name);
+
+  # Formatting
+  # alarm (bell)          (BEL)
+  substitute2 ("\$Fa", "\a");
+
+  # form feed             (FF)
+  substitute2 ("\$Ff", "\f");
+
+  # newline               (LF, NL)
+  substitute2 ("\$Fn", "\n");
+
+  # return                (CR)
+  substitute2 ("\$Fr", "\r");
+
+  # tab                   (HT, TAB)
+  substitute2 ("\$Ft", "\t");
+
+  # $$ - Print a $
+  s(\$\$)(\$)g;
+}
+
 sub substitute
 {
   my $format_line = shift;      # Used for $Fz variable substitution for EXEC line.
@@ -2407,37 +2463,36 @@ sub substitute
 
   # Wildcards - $*, $+*, $-*
   # Expand to $1 $2 $3 etc
-  my $temp_wildcard1 = ();
-  my $temp_wildcard2 = ();
-  my $temp_wildcard3 = ();
-  for(my $i=1;$i <= $#entvar+1; $i++)
-  {
-    $temp_wildcard1 = $temp_wildcard1 . "\$$i" . $wildcard_expansion_separator;
-    $temp_wildcard2 = $temp_wildcard2 . "\$\+$i" . $wildcard_expansion_separator;
-    $temp_wildcard3 = $temp_wildcard3 . "\$-$i" . $wildcard_expansion_separator;
-  }
+  # Only if we have at least one enterprise variable
+  if ($#entvar+1) {
+    my $temp_wildcard1 = "";
+    my $temp_wildcard2 = "";
+    my $temp_wildcard3 = "";
+    for(my $i=1;$i <= $#entvar+1; $i++)
+    {
+      $temp_wildcard1 = $temp_wildcard1 . "\$$i" . $wildcard_expansion_separator;
+      $temp_wildcard2 = $temp_wildcard2 . "\$\+$i" . $wildcard_expansion_separator;
+      $temp_wildcard3 = $temp_wildcard3 . "\$-$i" . $wildcard_expansion_separator;
+    }
 
-  # Trim off last wildcard separator
-  # TODO: Bug? Should it be checking $temp_wildcard1, $temp_wildcard2 or $temp_wildcard3 is defined?
-  if (defined ( $temp_wildcard1) )
-  {
+    # Trim off last wildcard separator
     my $end_trim = length($wildcard_expansion_separator);
     $temp_wildcard1 = substr($temp_wildcard1,0,-$end_trim);
     $temp_wildcard2 = substr($temp_wildcard2,0,-$end_trim);
     $temp_wildcard3 = substr($temp_wildcard3,0,-$end_trim);
+
+    #s(\$\*)($temp_wildcard1)g;
+    substitute2 ("\$\*", $temp_wildcard1);
+
+    s(\$\+\*)($temp_wildcard2)g;
+    substitute2 ("\$\+\*", $temp_wildcard2);
+
+    s(\$-\*)($temp_wildcard3)g;
+    substitute2 ("\$-\*", $temp_wildcard3);
   }
 
-  #s(\$\*)($temp_wildcard1)g;
-  substitute2 ("\$\*", $temp_wildcard1);
-
-  s(\$\+\*)($temp_wildcard2)g;
-  substitute2 ("\$\+\*", $temp_wildcard2);
-
-  s(\$-\*)($temp_wildcard3)g;
-  substitute2 ("\$-\*", $temp_wildcard3);
-
- # $v - Names of variable-bindings 
- # Count down backwards to make sure 10 is not mistaken for $1
+  # $v - Names of variable-bindings
+  # Count down backwards to make sure 10 is not mistaken for $1
   for(my $i=$#entvarname+1;$i > 0; $i--)
   {
     if ($net_snmp_perl_enable == 1)
@@ -2804,7 +2859,9 @@ sub substitute
   }
 
   # FORMAT line (only possible when doing EXEC line)
-  substitute2 ("\$Fz", "$format_line");
+  if (defined($format_line)) {
+    substitute2 ("\$Fz", "$format_line");
+  }
 
   # $$ - Print a $
   s(\$\$)(\$)g;
@@ -3426,7 +3483,7 @@ sub readtrap
 
   if ($DEBUGGING >= 2) 
   {
-    print "Reading trap.  Current time: " . scalar(localtime()). "\n";
+    print "Reading trap.  Current time: " . scalar(get_time()). "\n";
   }
 
   if ( $daemon == 1)
@@ -3448,41 +3505,45 @@ sub readtrap
   }
 
   my @localtime_array;
+  my @localtime_array_sql;
+
   if ( $daemon == 1 && $use_trap_time == 1 )	# Daemon mode only
   {
-    @localtime_array = localtime($trap_date_time_epoch);
+    @localtime_array = get_time($trap_date_time_epoch);
 
     if ($date_time_format eq "") {
-      $trap_date_time = localtime($trap_date_time_epoch);
+      $trap_date_time = get_time($trap_date_time_epoch);
     }
     else {
       $trap_date_time = strftime $date_time_format, @localtime_array;
     }
 
     if ($date_time_format_sql eq "") {
-      $trap_date_time_sql = localtime($trap_date_time_epoch);
+      $trap_date_time_sql = get_time_sql($trap_date_time_epoch);
     }
     else {
-      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array;
+      @localtime_array_sql = get_time_sql($trap_date_time_epoch);
+      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array_sql;
     }
     
   }
   else  # Standalone mode
   {
-    @localtime_array = localtime();
+    @localtime_array = get_time();
 
     if ($date_time_format eq "") {
-      $trap_date_time = localtime();
+      $trap_date_time = get_time();
     }
     else {
       $trap_date_time = strftime $date_time_format, @localtime_array;
     }
 
     if ($date_time_format_sql eq "") {
-      $trap_date_time_sql = localtime();
+      $trap_date_time_sql = get_time_sql();
     }
     else {
-      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array;
+      @localtime_array_sql = get_time_sql($trap_date_time_epoch);
+      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array_sql;
     }
   }
 
@@ -3650,7 +3711,7 @@ sub readtrap
     chomp ($temp2);       # Variable VALUE
     chomp ($line);
 
-    my $variable_fix;
+    my $variable_fix = 0;
     if ($linenum == 1)
     {
       if (defined($temp2) )	# Check if line 1 contains 'variable value' or just 'value'  
@@ -3963,6 +4024,19 @@ sub readtrap
     }
   }
 
+  if ($dns_normalise_case == 1) {
+    $agent_dns_name = lc $agent_dns_name;
+    if ($DEBUGGING >= 2) {
+      print "Agent host name changed to lower case: $agent_dns_name\n\n";
+    }
+  }
+  elsif ($dns_normalise_case == 2) {
+    $agent_dns_name = uc $agent_dns_name;
+    if ($DEBUGGING >= 2) {
+      print "Agent host name changed to upper case: $agent_dns_name\n\n";
+    }
+  }
+
   if ($strip_domain)
   {
     $var[0] = strip_domain_name($var[0], $strip_domain);
@@ -3972,6 +4046,19 @@ sub readtrap
   if ($DEBUGGING >= 1)
   {
     print "Trap received from $tempvar[0]: $tempvar[5]\n";
+  }
+
+  if ($dns_normalise_case == 1) {
+    $var[0] = lc $var[0];
+    if ($DEBUGGING >= 2) {
+      print "\nValue 0 host name changed to lower case: $var[0]\n\n";
+    }
+  }
+  elsif ($dns_normalise_case == 2) {
+    $var[0] = uc $var[0];
+    if ($DEBUGGING >= 2) {
+      print "\nValue 0 host name changed to upper case: $var[0]\n\n";
+    }
   }
 
   if ($DEBUGGING >= 2)
@@ -4345,9 +4432,13 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            print "Performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Performing substitution on custom column: $_\n";
+            }
             substitute();
-            print "Done performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Done performing substitution on custom column: $_\n";
+            }
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4382,9 +4473,13 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            print "Performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Performing substitution on custom column: $_\n";
+            }
             substitute();
-            print "Done performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Done performing substitution on custom column: $_\n";
+            }
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4418,9 +4513,13 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            print "Performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Performing substitution on custom column: $_\n";
+            }
             substitute();
-            print "Done performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Done performing substitution on custom column: $_\n";
+            }
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4454,9 +4553,13 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            print "Performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Performing substitution on custom column: $_\n";
+            }
             substitute();
-            print "Done performing substitution on custom column: $_\n";
+            if ($DEBUGGING >= 1) {
+              print "Done performing substitution on custom column: $_\n";
+            }
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4613,6 +4716,7 @@ sub loadsnmpttini {
   $snmptt_system_name = $cfg->val('General', 'snmptt_system_name');
   $multiple_event = $cfg->val('General', 'multiple_event');
   $dns_enable = $cfg->val('General', 'dns_enable');
+  $dns_normalise_case = $cfg->val('General', 'dns_normalise_case');
   $strip_domain = $cfg->val('General', 'strip_domain');
   @strip_domain_list = $cfg->val('General', 'strip_domain_list');
   $net_snmp_perl_enable = $cfg->val('General', 'net_snmp_perl_enable');
@@ -4638,6 +4742,7 @@ sub loadsnmpttini {
   $date_format = $cfg->val('General', 'date_format');
   $time_format = $cfg->val('General', 'time_format');
   $date_time_format = $cfg->val('General', 'date_time_format');
+  $date_time_utc = $cfg->val('General', 'date_time_utc');
 
   # DaemonMode
   $daemon_fork = $cfg->val('DaemonMode', 'daemon_fork');
@@ -4745,9 +4850,11 @@ sub loadsnmpttini {
 
   @sql_custom_columns = $cfg->val('SQL', 'sql_custom_columns');
   @sql_custom_columns_unknown = $cfg->val('SQL', 'sql_custom_columns_unknown');
+  @sql_custom_columns_statistics = $cfg->val('SQL', 'sql_custom_columns_statistics');
 
   $date_time_format_sql = $cfg->val('SQL', 'date_time_format_sql');
   $stat_time_format_sql = $cfg->val('SQL', 'stat_time_format_sql');
+  $date_time_utc_sql = $cfg->val('SQL', 'date_time_utc_sql');
   
   # Debugging
   if ($debugcmdline == 0) {
@@ -4772,6 +4879,7 @@ sub loadsnmpttini {
   }
   if (! defined ($multiple_event)) { $multiple_event = 0} ;
   if (! defined ($dns_enable)) { $dns_enable = 0} ;
+  if (! defined ($dns_normalise_case)) { $dns_normalise_case = 0} ;
   if (! defined ($strip_domain)) { $strip_domain = 0} ;
   if (! defined ($net_snmp_perl_enable)) { $net_snmp_perl_enable = 0} ;
   if (! defined ($net_snmp_perl_cache_enable)) { $net_snmp_perl_cache_enable = 1} ;
@@ -4797,6 +4905,8 @@ sub loadsnmpttini {
   if (! defined ($date_time_format)) { $date_time_format = ""} ;
   if (! defined ($date_time_format_sql)) { $date_time_format_sql = ""} ;
   if (! defined ($stat_time_format_sql)) { $stat_time_format_sql = ""} ;
+  if (! defined ($date_time_utc)) { $date_time_utc = 0} ;
+  if (! defined ($date_time_utc_sql)) { $date_time_utc_sql = 0} ;
 
   if (! defined ($daemon_fork)) { $daemon_fork = 1} ;
   if (! defined ($daemon_uid)) { $daemon_uid = ''} ;
@@ -4832,7 +4942,7 @@ sub loadsnmpttini {
   if (! defined ($syslog_system_facility)) { $syslog_system_facility = 'local0'} ;
   if (! defined ($syslog_system_level)) { $syslog_system_level = 'warning'} ;
   if (! defined ($eventlog_enable)) { $eventlog_enable = 0} ;
-  if (! defined ($eventlog_enable)) { $eventlog_enable = 'WARNING'} ;
+  if (! defined ($eventlog_type)) { $eventlog_type = 'WARNING'} ;
   if (! defined ($eventlog_system_enable)) { $eventlog_system_enable = 0} ;	
   if (! defined ($exec_enable)) { $exec_enable = 1} ;
   if (! defined ($pre_exec_enable)) { $pre_exec_enable = 1} ;
@@ -4890,6 +5000,7 @@ sub loadsnmpttini {
   if (! defined ($sql_win32_odbc_password)) { $sql_win32_odbc_password = ''} ;
   if (! (@sql_custom_columns)) { @sql_custom_columns = ()} ;
   if (! (@sql_custom_columns_unknown)) { @sql_custom_columns_unknown = ()} ;
+  if (! (@sql_custom_columns_statistics)) { @sql_custom_columns_statistics = ()} ;
   if (! defined ($DEBUGGING)) { $DEBUGGING = 0} ;
   if (! defined ($DEBUGGING_FILE)) { $DEBUGGING_FILE = ''} ;
 
@@ -4969,11 +5080,11 @@ sub syslog_system {
 sub log_system {
   my $message = $_[0];
 
-  my @localtime_array = localtime();
+  my @localtime_array = get_time();
   my $log_time;
 
   if ($date_time_format eq "") {
-    $log_time = localtime();
+    $log_time = get_time();
   }
   else {
     $log_time = strftime $date_time_format, @localtime_array;
@@ -5875,8 +5986,10 @@ sub my_mapEnum
   my $oid = shift;
   my $value = shift;
 
+  my $oid_value = $oid . "-" . $value;
+
   # Check cache first
-  my $my_mapEnum_cache_value = $my_mapEnum_cache{$oid};
+  my $my_mapEnum_cache_value = $my_mapEnum_cache{$oid_value};
   if ($my_mapEnum_cache_value) {
     if ($DEBUGGING >= 2)
     {      
@@ -5917,7 +6030,7 @@ sub my_mapEnum
   }
   # Update cache if net_snmp_perl_cache_enable is enabled.
   if ($net_snmp_perl_cache_enable == 1) {
-    $my_mapEnum_cache{$oid} = $result;
+    $my_mapEnum_cache{$oid_value} = $result;
   }
 
   return $result;
@@ -6129,10 +6242,28 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = localtime();
+      $stat_time_temp = get_time_sql();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, localtime();
+      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
+    }
+
+    my @t_sql_custom_columns_statistics = ();
+
+    if (@sql_custom_columns_statistics) {
+      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
+
+      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
+        $_ = $t_sql_custom_columns_statistics[$i];
+        if ($DEBUGGING >= 1) {
+          print "Performing substitution on custom column: $_\n";
+        }
+        substitute_sql_stat();
+        if ($DEBUGGING >= 1) {
+          print "Done performing substitution on custom column: $_\n";
+        }
+        $t_sql_custom_columns_statistics[$i] = $_;
+      }
     }
     
     if ($unknown_trap_nodes_match_mode != 0) {
@@ -6142,7 +6273,8 @@ sub log_statistics {
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
         "total_skipped", $g_total_traps_skipped,
-        "total_unknown", $g_total_traps_unknown);
+        "total_unknown", $g_total_traps_unknown,
+        @t_sql_custom_columns_statistics);
     }
     else {
       mysql_insert($mysql_dbi_table_statistics,
@@ -6150,7 +6282,8 @@ sub log_statistics {
       "total_received", $g_total_traps_received,
       "total_translated", $g_total_traps_translated,
       "total_ignored", $g_total_traps_ignored,
-      "total_unknown", $g_total_traps_unknown);
+      "total_unknown", $g_total_traps_unknown,
+      @t_sql_custom_columns_statistics);
     }
   }
 
@@ -6159,10 +6292,28 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = localtime();
+      $stat_time_temp = get_time_sql();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, localtime();
+      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
+    }
+
+    my @t_sql_custom_columns_statistics = ();
+
+    if (@sql_custom_columns_statistics) {
+      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
+
+      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
+        $_ = $t_sql_custom_columns_statistics[$i];
+        if ($DEBUGGING >= 1) {
+          print "Performing substitution on custom column: $_\n";
+        }
+        substitute_sql_stat();
+        if ($DEBUGGING >= 1) {
+          print "Done performing substitution on custom column: $_\n";
+        }
+        $t_sql_custom_columns_statistics[$i] = $_;
+      }
     }
 
     if ($unknown_trap_nodes_match_mode != 0) {
@@ -6172,7 +6323,8 @@ sub log_statistics {
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
         "total_skipped", $g_total_traps_skipped,
-        "total_unknown", $g_total_traps_unknown);
+        "total_unknown", $g_total_traps_unknown,
+        @t_sql_custom_columns_statistics);
     }
     else {
         postgresql_insert($postgresql_dbi_table_statistics,
@@ -6180,7 +6332,8 @@ sub log_statistics {
         "total_received", $g_total_traps_received,
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
-        "total_unknown", $g_total_traps_unknown);
+        "total_unknown", $g_total_traps_unknown,
+        @t_sql_custom_columns_statistics);
     }
   }
 
@@ -6189,10 +6342,28 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = localtime();
+      $stat_time_temp = get_time_sql();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, localtime();
+      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
+    }
+
+    my @t_sql_custom_columns_statistics = ();
+
+    if (@sql_custom_columns_statistics) {
+      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
+
+      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
+        $_ = $t_sql_custom_columns_statistics[$i];
+        if ($DEBUGGING >= 1) {
+          print "Performing substitution on custom column: $_\n";
+        }
+        substitute_sql_stat();
+        if ($DEBUGGING >= 1) {
+          print "Done performing substitution on custom column: $_\n";
+        }
+        $t_sql_custom_columns_statistics[$i] = $_;
+      }
     }
 
     if ($unknown_trap_nodes_match_mode != 0) {
@@ -6202,7 +6373,8 @@ sub log_statistics {
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
         "total_skipped", $g_total_traps_skipped,
-        "total_unknown", $g_total_traps_unknown);
+        "total_unknown", $g_total_traps_unknown,
+        @t_sql_custom_columns_statistics);
     }
     else {
         odbc_insert($dbd_odbc_table_statistics,
@@ -6210,7 +6382,8 @@ sub log_statistics {
         "total_received", $g_total_traps_received,
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
-        "total_unknown", $g_total_traps_unknown);
+        "total_unknown", $g_total_traps_unknown,
+        @t_sql_custom_columns_statistics);
     }
   }
 
@@ -6219,12 +6392,30 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = localtime();
+      $stat_time_temp = get_time_sql();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, localtime();
+      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
     }
-    
+
+    my @t_sql_custom_columns_statistics = ();
+
+    if (@sql_custom_columns_statistics) {
+      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
+
+      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
+        $_ = $t_sql_custom_columns_statistics[$i];
+        if ($DEBUGGING >= 1) {
+          print "Performing substitution on custom column: $_\n";
+        }
+        substitute_sql_stat();
+        if ($DEBUGGING >= 1) {
+          print "Done performing substitution on custom column: $_\n";
+        }
+        $t_sql_custom_columns_statistics[$i] = $_;
+      }
+    }
+
     if ($unknown_trap_nodes_match_mode != 0) {
       sql_win32_odbc_insert($sql_win32_odbc_table_statistics,
       "stat_time", $stat_time_temp,
@@ -6232,7 +6423,8 @@ sub log_statistics {
       "total_translated", $g_total_traps_translated,
       "total_ignored", $g_total_traps_ignored,
       "total_skipped", $g_total_traps_skipped,
-      "total_unknown", $g_total_traps_unknown);
+      "total_unknown", $g_total_traps_unknown,
+      @t_sql_custom_columns_statistics);
     }
     else {
       sql_win32_odbc_insert($sql_win32_odbc_table_statistics,
@@ -6240,7 +6432,8 @@ sub log_statistics {
       "total_received", $g_total_traps_received,
       "total_translated", $g_total_traps_translated,
       "total_ignored", $g_total_traps_ignored,
-      "total_unknown", $g_total_traps_unknown);
+      "total_unknown", $g_total_traps_unknown,
+      @t_sql_custom_columns_statistics);
     }
   }
 
@@ -6851,26 +7044,47 @@ sub sql_win32_odbc_insert {
   #print "sql_statement: $sql_statement\n";
    
   if (defined ($dbh_win32_odbc)) {
-    if (defined ($dbh_win32_odbc->Sql($sql_statement)))
-    {
-      my $msg = "Win32::ODBC error: Unable to perform INSERT INTO: ".Win32::ODBC::Error();
-      warn $msg, "\n";
-
-      if ($DEBUGGING >= 1)
+    my $dbh_win32_odbc_retries = 3;
+    while ($dbh_win32_odbc_retries) {
+      if (defined ($dbh_win32_odbc->Sql($sql_statement))) # Error
       {
-        print $msg, "\n";
+        my $msg = "Win32::ODBC error: Unable to perform INSERT INTO: ".Win32::ODBC::Error();
+        warn $msg, "\n";
+
+        if ($DEBUGGING >= 1)
+        {
+          print $msg, "\n";
+        }
+
+        if ($eventlog_system_enable == 1)
+        {
+          eventlog_system($msg,17,$eventlog_error);
+        }
+        
+        $msg = "Attempting to re-open Win32::ODBC connection";
+        warn $msg, "\n";
+
+        if ($DEBUGGING >= 1)
+        {
+          print $msg, "\n";
+        }
+
+        if ($eventlog_system_enable == 1)
+        {
+          eventlog_system($msg,17,$eventlog_error);
+        }
+
+        dbh_win32_odbc_close();
+        dbh_win32_odbc_connect();
+        
+        $dbh_win32_odbc_retries--;
+        sleep 0.1;
       }
-
-      if ($eventlog_system_enable == 1)
-      {
-        eventlog_system($msg,17,$eventlog_error);
+      else { # No error
+        return 1;
       }
     }
-    else
-    {
-      return 1;
-    }
-  return 0;
+    return 0;
   }
 }
 
@@ -6920,54 +7134,55 @@ sub preexec_run {
         print "\n\nPREEXEC line(s):\n";
       }
 
-      if (defined ($event2[9][0])) # if PREEXEC string has been defined
+      if (defined ($event2[9][0]))
       {
-        print "PREEXEC defined\n";
-        if (defined ($event2[9][0]))
+        #print "PREEXEC defined\n";
+        for (my $i=0; defined($event2[9][$i]); $i++)
         {
-          for (my $i=0; defined($event2[9][$i]); $i++)
-          {
-            $_ = $event2[9][$i];
+          $_ = $event2[9][$i];
 
+          if ($DEBUGGING >= 1) {
             print "Performing substitution on PREEXEC line: $_\n";
-            substitute();
+          }
+          substitute();
+          if ($DEBUGGING >= 1) {
             print "Done performing substitution on PREEXEC line: $_\n";
+          }
 
-            my $command = $_;
+          my $command = $_;
 
-            if ($pre_exec_enable == 1)
+          if ($pre_exec_enable == 1)
+          {
+            if ($DEBUGGING >= 1)
             {
-              if ($DEBUGGING >= 1)
-              {
-                print "PREEXEC command: $command\n";
-              }
-              # Execute command
-
-              if ($exec_escape == 1) {
-                # Escape wildcard characters
-                $command =~ s/\*/\\\*/g;
-                $command =~ s/\?/\\\?/g;
-              }
-              my $result = `$command`;
-              chomp $result;
-              # Remove spaces before and after
-              $result =~ /^\s*(.*?)\s*$/;
-              $result = $1;
-
-              if ($result eq '') {
-                $result = "(no output from PREEXEC)\n";
-              }
-              print "        command output: $result\n";
-              push (@preexec_var, $result);
+              print "PREEXEC command: $command\n";
             }
+            # Execute command
+
+            if ($exec_escape == 1) {
+              # Escape wildcard characters
+              $command =~ s/\*/\\\*/g;
+              $command =~ s/\?/\\\?/g;
+            }
+            my $result = `$command`;
+            chomp $result;
+            # Remove spaces before and after
+            $result =~ /^\s*(.*?)\s*$/;
+            $result = $1;
+
+            if ($result eq '') {
+              $result = "(no output from PREEXEC)\n";
+            }
+            print "        command output: $result\n";
+            push (@preexec_var, $result);
           }
         }
-        else
+      }
+      else
+      {
+        if ($DEBUGGING >= 1)
         {
-          if ($DEBUGGING >= 1)
-          {
-            print "  PREEXEC line not defined\n";
-          }
+          print "  PREEXEC line not defined\n";
         }
       }
 }
@@ -7018,6 +7233,21 @@ sub ip_to_name {
             $hostname = undef;
         }
     }
+
+    if ($hostname) {
+      if ($dns_normalise_case == 1) {
+        $hostname = lc $hostname;
+        if ($DEBUGGING >= 2) {
+          print "  Host name changed to lower case: $hostname\n\n";
+        }
+      }
+      elsif ($dns_normalise_case == 2) {
+        $hostname = uc $hostname;
+        if ($DEBUGGING >= 2) {
+          print "  Host name changed to upper case: $hostname\n\n";
+        }
+      }
+    }
     return $hostname;
 }
 
@@ -7054,3 +7284,45 @@ sub name_to_ip {
     return @ips;
 }
 
+
+sub get_time {
+  my $t_time = shift;
+
+  if (!defined($t_time)) {
+    if ($date_time_utc == 1) {
+        return gmtime();
+    }
+    else {
+        return localtime();
+    }
+  }
+  else {
+    if ($date_time_utc == 1) {
+        return gmtime($t_time);
+    }
+    else {
+        return localtime($t_time);
+    }
+  }
+}
+
+sub get_time_sql {
+  my $t_time = shift;
+
+  if (!defined($t_time)) {
+    if ($date_time_utc_sql == 1) {
+        return gmtime();
+    }
+    else {
+        return localtime();
+    }
+  }
+  else {
+    if ($date_time_utc_sql == 1) {
+        return gmtime($t_time);
+    }
+    else {
+        return localtime($t_time);
+    }
+  }
+}

--- a/snmptt/snmptt
+++ b/snmptt/snmptt
@@ -1322,15 +1322,19 @@ if ($daemon == 1)
 
           $filesuccess = 0;
         }
-        
-        my $lock_status = acquire_lock($fh_FILE, 5);
-        if ($lock_status == 0) {
-          if ($DEBUGGING >= 1)
-          {
-            print "Could not acquire flock read lock\n";
+
+
+        if ($locking_method == 0)
+        {
+          my $lock_status = acquire_lock($fh_FILE, 5);
+          if ($lock_status == 0) {
+            if ($DEBUGGING >= 1)
+            {
+              print "Could not acquire flock read lock\n";
+            }
+            warn "Could not acquire flock read lock\n";
           }
-          warn "Could not acquire flock read lock\n";
-        }
+         }
         
 
         $input = $fh_FILE;

--- a/snmptt/snmptt
+++ b/snmptt/snmptt
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# SNMPTT 1.5.1beta1
+# SNMPTT 1.5
 #
 # Copyright 2002-2022 Alex Burger
 # alex_b@users.sourceforge.net
@@ -48,7 +48,7 @@
 use strict;
 use warnings;
 
-my $snmptt_version = "1.5.1beta1";
+my $snmptt_version = "1.5";
 
 sub showversion
 {
@@ -169,7 +169,6 @@ my $snmptt_system_name;
 #my $daemon;
 my $multiple_event;
 my $dns_enable;
-my $dns_normalise_case;
 my $strip_domain;
 my @strip_domain_list;
 my $net_snmp_perl_enable;
@@ -195,10 +194,8 @@ my $ipv6_enable;
 my $date_format;
 my $time_format;
 my $date_time_format;
-my $date_time_utc;
 my $date_time_format_sql;
 my $stat_time_format_sql;
-my $date_time_utc_sql;
 
 # DaemonMode
 my $daemon_fork;
@@ -306,7 +303,6 @@ my $sql_win32_odbc_password;
 
 my @sql_custom_columns;
 my @sql_custom_columns_unknown;
-my @sql_custom_columns_statistics;
 
 # TrapFiles
 my @snmptt_conf_files;
@@ -320,7 +316,38 @@ findsnmpttini();
 loadsnmpttini();
 
 ##############################################################################
+#
+#  File Locking
+#
 
+my $locking_method = 0;
+
+eval 'require Fcntl;';
+if ($@) {
+  $locking_method = 1;
+  warn $@;
+  print "\nFile locking not available.  Rename method will be used for spool file.\n";
+}
+else {
+  require Fcntl;
+}
+
+sub acquire_lock {
+    my ($fh,$timeout) = @_;
+    my $returnval = 0;
+    for (my $i = 0; $i < ($timeout / 0.2); $i++){
+        #Attempt to acquire a shared lock.  
+        $returnval = flock($fh, 1 | 4);
+        if ($returnval < 1){
+            select(undef, undef, undef, 0.2);
+        } else {
+            return($returnval);
+        }
+    }
+    return(0)
+}
+
+###############################################################################
 use Text::ParseWords;
 use POSIX qw(strftime);
 use Sys::Hostname;
@@ -352,7 +379,7 @@ if ($DEBUGGING >= 1)
   }
 
   # print out time
-  print "********** SNMPTT $snmptt_version started: ",scalar(get_time($g_start_time))," **********\n\n";
+  print "********** SNMPTT $snmptt_version started: ",scalar(localtime($g_start_time))," **********\n\n";
   if ($sleep < 1) {
     print "Note: snmptt.ini sleep setting is less than 1 so \'Sleeping for x seconds\' will be supressed in the debug log.\n\n";
   }
@@ -760,17 +787,11 @@ if ($daemon == 1)
     }
   }
 
-  if (exists ($SIG{HUP})) {
-    $SIG{HUP} = \&signal_handler_reload;
-  }
+  $SIG{HUP} = \&signal_handler_reload;
 
-  if (exists ($SIG{TERM})) {
-    $SIG{TERM} = \&signal_handler_die;
-  }
+  $SIG{TERM} = \&signal_handler_die;
 
-  if (exists ($SIG{USR1})) {
-    $SIG{USR1} = \&signal_log_statistics;
-  }
+  $SIG{USR1} = \&signal_log_statistics;
 
   $timetoreload = 0;
   $timetodie = 0;
@@ -1027,11 +1048,9 @@ if ($daemon == 1)
 
 
       if ($DEBUGGING >= 1) {
-        if (defined ($fh_DEBUGFILE)) {
-          print $fh_DEBUGFILE "Closing debug file $DEBUGGING_FILE\n";
-          # Close debug file (if it is open) before changing users and re-open after
-          close($fh_DEBUGFILE);
-        }
+        print $fh_DEBUGFILE "Closing debug file $DEBUGGING_FILE\n";
+        # Close debug file (if it is open) before changing users and re-open after
+        close($fh_DEBUGFILE);
       }
 	  
 	    # Change owner of debug file so $daemon_uid can write to it.
@@ -1097,7 +1116,7 @@ if ($daemon == 1)
       my $duplicate_traps_current_time = time();
       foreach my $key (sort keys %duplicate_traps)
       {
-        #print "Previous trap digest: $key: " . get_time($duplicate_traps{$key}) . "\n";
+        #print "Previous trap digest: $key: " . localtime($duplicate_traps{$key}) . "\n";
         if ($duplicate_traps{$key} < $duplicate_traps_current_time - $duplicate_trap_window) {
           # Purge the record
           delete $duplicate_traps{$key};
@@ -1291,6 +1310,16 @@ if ($daemon == 1)
           $filesuccess = 0;
         }
 
+
+        my $lock_status = acquire_lock($fh_FILE, 5);
+        if ($lock_status == 0) {
+          if ($DEBUGGING >= 1)
+          {
+            print "Could not acquire flock read lock\n";
+          }
+          warn "Could not acquire flock read lock\n";
+        }
+
         $input = $fh_FILE;
 
         my $readtrap_result = readtrap();      # Read trap from STDIN or file
@@ -1425,7 +1454,7 @@ if ($daemon == 1)
 
   if ($DEBUGGING >= 1)
   {
-    print "SNMPTT $snmptt_version shutdown: ",scalar(get_time()),"\n\n";
+    print "SNMPTT $snmptt_version shutdown: ",scalar(localtime),"\n\n";
     print "Total traps received:    $g_total_traps_received\n";
     print "Total traps translated:  $g_total_traps_translated\n";
     print "Total traps ignored:     $g_total_traps_ignored\n";
@@ -2117,13 +2146,9 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              if ($DEBUGGING >= 1) {
-                print "Performing substitution on custom column: $_\n";
-              }
+              print "Performing substitution on custom column: $_\n";
               substitute();
-              if ($DEBUGGING >= 1) {
-                print "Done performing substitution on custom column: $_\n";
-              }
+              print "Done performing substitution on custom column: $_\n";
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2166,13 +2191,9 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              if ($DEBUGGING >= 1) {
-                print "Performing substitution on custom column: $_\n";
-              }
+              print "Performing substitution on custom column: $_\n";
               substitute();
-              if ($DEBUGGING >= 1) {
-                print "Done performing substitution on custom column: $_\n";
-              }
+              print "Done performing substitution on custom column: $_\n";
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2213,13 +2234,9 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              if ($DEBUGGING >= 1) {
-                print "Performing substitution on custom column: $_\n";
-              }
+              print "Performing substitution on custom column: $_\n";
               substitute();
-              if ($DEBUGGING >= 1) {
-                print "Done performing substitution on custom column: $_\n";
-              }
+              print "Done performing substitution on custom column: $_\n";
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2260,13 +2277,9 @@ sub processtrap
             
             for (my $i = 1; $i <= $#t_sql_custom_columns; $i+=2) {
               $_ = $t_sql_custom_columns[$i];
-              if ($DEBUGGING >= 1) {
-                print "Performing substitution on custom column: $_\n";
-              }
+              print "Performing substitution on custom column: $_\n";
               substitute();
-              if ($DEBUGGING >= 1) {
-                print "Done performing substitution on custom column: $_\n";
-              }                
+              print "Done performing substitution on custom column: $_\n";
               $t_sql_custom_columns[$i] = $_;
             }
           }
@@ -2386,33 +2399,6 @@ sub processtrap
   } #while defined..
 }
 
-sub substitute_sql_stat
-{
-  my $format_line = shift;      # Used for $Fz variable substitution for EXEC line.
-
-  # $H - Host name of the system running SNMPTT
-  substitute2 ("\$H", $snmptt_system_name);
-
-  # Formatting
-  # alarm (bell)          (BEL)
-  substitute2 ("\$Fa", "\a");
-
-  # form feed             (FF)
-  substitute2 ("\$Ff", "\f");
-
-  # newline               (LF, NL)
-  substitute2 ("\$Fn", "\n");
-
-  # return                (CR)
-  substitute2 ("\$Fr", "\r");
-
-  # tab                   (HT, TAB)
-  substitute2 ("\$Ft", "\t");
-
-  # $$ - Print a $
-  s(\$\$)(\$)g;
-}
-
 sub substitute
 {
   my $format_line = shift;      # Used for $Fz variable substitution for EXEC line.
@@ -2421,36 +2407,37 @@ sub substitute
 
   # Wildcards - $*, $+*, $-*
   # Expand to $1 $2 $3 etc
-  # Only if we have at least one enterprise variable
-  if ($#entvar+1) {
-    my $temp_wildcard1 = "";
-    my $temp_wildcard2 = "";
-    my $temp_wildcard3 = "";
-    for(my $i=1;$i <= $#entvar+1; $i++)
-    {
-      $temp_wildcard1 = $temp_wildcard1 . "\$$i" . $wildcard_expansion_separator;
-      $temp_wildcard2 = $temp_wildcard2 . "\$\+$i" . $wildcard_expansion_separator;
-      $temp_wildcard3 = $temp_wildcard3 . "\$-$i" . $wildcard_expansion_separator;
-    }
+  my $temp_wildcard1 = ();
+  my $temp_wildcard2 = ();
+  my $temp_wildcard3 = ();
+  for(my $i=1;$i <= $#entvar+1; $i++)
+  {
+    $temp_wildcard1 = $temp_wildcard1 . "\$$i" . $wildcard_expansion_separator;
+    $temp_wildcard2 = $temp_wildcard2 . "\$\+$i" . $wildcard_expansion_separator;
+    $temp_wildcard3 = $temp_wildcard3 . "\$-$i" . $wildcard_expansion_separator;
+  }
 
-    # Trim off last wildcard separator
+  # Trim off last wildcard separator
+  # TODO: Bug? Should it be checking $temp_wildcard1, $temp_wildcard2 or $temp_wildcard3 is defined?
+  if (defined ( $temp_wildcard1) )
+  {
     my $end_trim = length($wildcard_expansion_separator);
     $temp_wildcard1 = substr($temp_wildcard1,0,-$end_trim);
     $temp_wildcard2 = substr($temp_wildcard2,0,-$end_trim);
     $temp_wildcard3 = substr($temp_wildcard3,0,-$end_trim);
-
-    #s(\$\*)($temp_wildcard1)g;
-    substitute2 ("\$\*", $temp_wildcard1);
-
-    s(\$\+\*)($temp_wildcard2)g;
-    substitute2 ("\$\+\*", $temp_wildcard2);
-
-    s(\$-\*)($temp_wildcard3)g;
-    substitute2 ("\$-\*", $temp_wildcard3);
   }
 
-  # $v - Names of variable-bindings
-  # Count down backwards to make sure 10 is not mistaken for $1
+  #s(\$\*)($temp_wildcard1)g;
+  substitute2 ("\$\*", $temp_wildcard1);
+
+  s(\$\+\*)($temp_wildcard2)g;
+  substitute2 ("\$\+\*", $temp_wildcard2);
+
+  s(\$-\*)($temp_wildcard3)g;
+  substitute2 ("\$-\*", $temp_wildcard3);
+
+ # $v - Names of variable-bindings 
+ # Count down backwards to make sure 10 is not mistaken for $1
   for(my $i=$#entvarname+1;$i > 0; $i--)
   {
     if ($net_snmp_perl_enable == 1)
@@ -2817,9 +2804,7 @@ sub substitute
   }
 
   # FORMAT line (only possible when doing EXEC line)
-  if (defined($format_line)) {
-    substitute2 ("\$Fz", "$format_line");
-  }
+  substitute2 ("\$Fz", "$format_line");
 
   # $$ - Print a $
   s(\$\$)(\$)g;
@@ -3441,7 +3426,7 @@ sub readtrap
 
   if ($DEBUGGING >= 2) 
   {
-    print "Reading trap.  Current time: " . scalar(get_time()). "\n";
+    print "Reading trap.  Current time: " . scalar(localtime()). "\n";
   }
 
   if ( $daemon == 1)
@@ -3463,45 +3448,41 @@ sub readtrap
   }
 
   my @localtime_array;
-  my @localtime_array_sql;
-
   if ( $daemon == 1 && $use_trap_time == 1 )	# Daemon mode only
   {
-    @localtime_array = get_time($trap_date_time_epoch);
+    @localtime_array = localtime($trap_date_time_epoch);
 
     if ($date_time_format eq "") {
-      $trap_date_time = get_time($trap_date_time_epoch);
+      $trap_date_time = localtime($trap_date_time_epoch);
     }
     else {
       $trap_date_time = strftime $date_time_format, @localtime_array;
     }
 
     if ($date_time_format_sql eq "") {
-      $trap_date_time_sql = get_time_sql($trap_date_time_epoch);
+      $trap_date_time_sql = localtime($trap_date_time_epoch);
     }
     else {
-      @localtime_array_sql = get_time_sql($trap_date_time_epoch);
-      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array_sql;
+      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array;
     }
     
   }
   else  # Standalone mode
   {
-    @localtime_array = get_time();
+    @localtime_array = localtime();
 
     if ($date_time_format eq "") {
-      $trap_date_time = get_time();
+      $trap_date_time = localtime();
     }
     else {
       $trap_date_time = strftime $date_time_format, @localtime_array;
     }
 
     if ($date_time_format_sql eq "") {
-      $trap_date_time_sql = get_time_sql();
+      $trap_date_time_sql = localtime();
     }
     else {
-      @localtime_array_sql = get_time_sql($trap_date_time_epoch);
-      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array_sql;
+      $trap_date_time_sql = strftime $date_time_format_sql, @localtime_array;
     }
   }
 
@@ -3669,7 +3650,7 @@ sub readtrap
     chomp ($temp2);       # Variable VALUE
     chomp ($line);
 
-    my $variable_fix = 0;
+    my $variable_fix;
     if ($linenum == 1)
     {
       if (defined($temp2) )	# Check if line 1 contains 'variable value' or just 'value'  
@@ -3982,19 +3963,6 @@ sub readtrap
     }
   }
 
-  if ($dns_normalise_case == 1) {
-    $agent_dns_name = lc $agent_dns_name;
-    if ($DEBUGGING >= 2) {
-      print "Agent host name changed to lower case: $agent_dns_name\n\n";
-    }
-  }
-  elsif ($dns_normalise_case == 2) {
-    $agent_dns_name = uc $agent_dns_name;
-    if ($DEBUGGING >= 2) {
-      print "Agent host name changed to upper case: $agent_dns_name\n\n";
-    }
-  }
-
   if ($strip_domain)
   {
     $var[0] = strip_domain_name($var[0], $strip_domain);
@@ -4004,19 +3972,6 @@ sub readtrap
   if ($DEBUGGING >= 1)
   {
     print "Trap received from $tempvar[0]: $tempvar[5]\n";
-  }
-
-  if ($dns_normalise_case == 1) {
-    $var[0] = lc $var[0];
-    if ($DEBUGGING >= 2) {
-      print "\nValue 0 host name changed to lower case: $var[0]\n\n";
-    }
-  }
-  elsif ($dns_normalise_case == 2) {
-    $var[0] = uc $var[0];
-    if ($DEBUGGING >= 2) {
-      print "\nValue 0 host name changed to upper case: $var[0]\n\n";
-    }
   }
 
   if ($DEBUGGING >= 2)
@@ -4390,13 +4345,9 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            if ($DEBUGGING >= 1) {
-              print "Performing substitution on custom column: $_\n";
-            }
+            print "Performing substitution on custom column: $_\n";
             substitute();
-            if ($DEBUGGING >= 1) {
-              print "Done performing substitution on custom column: $_\n";
-            }
+            print "Done performing substitution on custom column: $_\n";
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4431,13 +4382,9 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            if ($DEBUGGING >= 1) {
-              print "Performing substitution on custom column: $_\n";
-            }
+            print "Performing substitution on custom column: $_\n";
             substitute();
-            if ($DEBUGGING >= 1) {
-              print "Done performing substitution on custom column: $_\n";
-            }
+            print "Done performing substitution on custom column: $_\n";
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4471,13 +4418,9 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            if ($DEBUGGING >= 1) {
-              print "Performing substitution on custom column: $_\n";
-            }
+            print "Performing substitution on custom column: $_\n";
             substitute();
-            if ($DEBUGGING >= 1) {
-              print "Done performing substitution on custom column: $_\n";
-            }
+            print "Done performing substitution on custom column: $_\n";
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4511,13 +4454,9 @@ sub searchfortrap
             
           for (my $i = 1; $i <= $#t_sql_custom_columns_unknown; $i+=2) {
             $_ = $t_sql_custom_columns_unknown[$i];
-            if ($DEBUGGING >= 1) {
-              print "Performing substitution on custom column: $_\n";
-            }
+            print "Performing substitution on custom column: $_\n";
             substitute();
-            if ($DEBUGGING >= 1) {
-              print "Done performing substitution on custom column: $_\n";
-            }
+            print "Done performing substitution on custom column: $_\n";
             $t_sql_custom_columns_unknown[$i] = $_;
           }
         }
@@ -4674,7 +4613,6 @@ sub loadsnmpttini {
   $snmptt_system_name = $cfg->val('General', 'snmptt_system_name');
   $multiple_event = $cfg->val('General', 'multiple_event');
   $dns_enable = $cfg->val('General', 'dns_enable');
-  $dns_normalise_case = $cfg->val('General', 'dns_normalise_case');
   $strip_domain = $cfg->val('General', 'strip_domain');
   @strip_domain_list = $cfg->val('General', 'strip_domain_list');
   $net_snmp_perl_enable = $cfg->val('General', 'net_snmp_perl_enable');
@@ -4700,7 +4638,6 @@ sub loadsnmpttini {
   $date_format = $cfg->val('General', 'date_format');
   $time_format = $cfg->val('General', 'time_format');
   $date_time_format = $cfg->val('General', 'date_time_format');
-  $date_time_utc = $cfg->val('General', 'date_time_utc');
 
   # DaemonMode
   $daemon_fork = $cfg->val('DaemonMode', 'daemon_fork');
@@ -4808,11 +4745,9 @@ sub loadsnmpttini {
 
   @sql_custom_columns = $cfg->val('SQL', 'sql_custom_columns');
   @sql_custom_columns_unknown = $cfg->val('SQL', 'sql_custom_columns_unknown');
-  @sql_custom_columns_statistics = $cfg->val('SQL', 'sql_custom_columns_statistics');
 
   $date_time_format_sql = $cfg->val('SQL', 'date_time_format_sql');
   $stat_time_format_sql = $cfg->val('SQL', 'stat_time_format_sql');
-  $date_time_utc_sql = $cfg->val('SQL', 'date_time_utc_sql');
   
   # Debugging
   if ($debugcmdline == 0) {
@@ -4837,7 +4772,6 @@ sub loadsnmpttini {
   }
   if (! defined ($multiple_event)) { $multiple_event = 0} ;
   if (! defined ($dns_enable)) { $dns_enable = 0} ;
-  if (! defined ($dns_normalise_case)) { $dns_normalise_case = 0} ;
   if (! defined ($strip_domain)) { $strip_domain = 0} ;
   if (! defined ($net_snmp_perl_enable)) { $net_snmp_perl_enable = 0} ;
   if (! defined ($net_snmp_perl_cache_enable)) { $net_snmp_perl_cache_enable = 1} ;
@@ -4863,8 +4797,6 @@ sub loadsnmpttini {
   if (! defined ($date_time_format)) { $date_time_format = ""} ;
   if (! defined ($date_time_format_sql)) { $date_time_format_sql = ""} ;
   if (! defined ($stat_time_format_sql)) { $stat_time_format_sql = ""} ;
-  if (! defined ($date_time_utc)) { $date_time_utc = 0} ;
-  if (! defined ($date_time_utc_sql)) { $date_time_utc_sql = 0} ;
 
   if (! defined ($daemon_fork)) { $daemon_fork = 1} ;
   if (! defined ($daemon_uid)) { $daemon_uid = ''} ;
@@ -4900,7 +4832,7 @@ sub loadsnmpttini {
   if (! defined ($syslog_system_facility)) { $syslog_system_facility = 'local0'} ;
   if (! defined ($syslog_system_level)) { $syslog_system_level = 'warning'} ;
   if (! defined ($eventlog_enable)) { $eventlog_enable = 0} ;
-  if (! defined ($eventlog_type)) { $eventlog_type = 'WARNING'} ;
+  if (! defined ($eventlog_enable)) { $eventlog_enable = 'WARNING'} ;
   if (! defined ($eventlog_system_enable)) { $eventlog_system_enable = 0} ;	
   if (! defined ($exec_enable)) { $exec_enable = 1} ;
   if (! defined ($pre_exec_enable)) { $pre_exec_enable = 1} ;
@@ -4958,7 +4890,6 @@ sub loadsnmpttini {
   if (! defined ($sql_win32_odbc_password)) { $sql_win32_odbc_password = ''} ;
   if (! (@sql_custom_columns)) { @sql_custom_columns = ()} ;
   if (! (@sql_custom_columns_unknown)) { @sql_custom_columns_unknown = ()} ;
-  if (! (@sql_custom_columns_statistics)) { @sql_custom_columns_statistics = ()} ;
   if (! defined ($DEBUGGING)) { $DEBUGGING = 0} ;
   if (! defined ($DEBUGGING_FILE)) { $DEBUGGING_FILE = ''} ;
 
@@ -5038,11 +4969,11 @@ sub syslog_system {
 sub log_system {
   my $message = $_[0];
 
-  my @localtime_array = get_time();
+  my @localtime_array = localtime();
   my $log_time;
 
   if ($date_time_format eq "") {
-    $log_time = get_time();
+    $log_time = localtime();
   }
   else {
     $log_time = strftime $date_time_format, @localtime_array;
@@ -5944,10 +5875,8 @@ sub my_mapEnum
   my $oid = shift;
   my $value = shift;
 
-  my $oid_value = $oid . "-" . $value;
-
   # Check cache first
-  my $my_mapEnum_cache_value = $my_mapEnum_cache{$oid_value};
+  my $my_mapEnum_cache_value = $my_mapEnum_cache{$oid};
   if ($my_mapEnum_cache_value) {
     if ($DEBUGGING >= 2)
     {      
@@ -5988,7 +5917,7 @@ sub my_mapEnum
   }
   # Update cache if net_snmp_perl_cache_enable is enabled.
   if ($net_snmp_perl_cache_enable == 1) {
-    $my_mapEnum_cache{$oid_value} = $result;
+    $my_mapEnum_cache{$oid} = $result;
   }
 
   return $result;
@@ -6200,28 +6129,10 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = get_time_sql();
+      $stat_time_temp = localtime();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
-    }
-
-    my @t_sql_custom_columns_statistics = ();
-
-    if (@sql_custom_columns_statistics) {
-      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
-
-      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
-        $_ = $t_sql_custom_columns_statistics[$i];
-        if ($DEBUGGING >= 1) {
-          print "Performing substitution on custom column: $_\n";
-        }
-        substitute_sql_stat();
-        if ($DEBUGGING >= 1) {
-          print "Done performing substitution on custom column: $_\n";
-        }
-        $t_sql_custom_columns_statistics[$i] = $_;
-      }
+      $stat_time_temp = strftime $stat_time_format_sql, localtime();
     }
     
     if ($unknown_trap_nodes_match_mode != 0) {
@@ -6231,8 +6142,7 @@ sub log_statistics {
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
         "total_skipped", $g_total_traps_skipped,
-        "total_unknown", $g_total_traps_unknown,
-        @t_sql_custom_columns_statistics);
+        "total_unknown", $g_total_traps_unknown);
     }
     else {
       mysql_insert($mysql_dbi_table_statistics,
@@ -6240,8 +6150,7 @@ sub log_statistics {
       "total_received", $g_total_traps_received,
       "total_translated", $g_total_traps_translated,
       "total_ignored", $g_total_traps_ignored,
-      "total_unknown", $g_total_traps_unknown,
-      @t_sql_custom_columns_statistics);
+      "total_unknown", $g_total_traps_unknown);
     }
   }
 
@@ -6250,28 +6159,10 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = get_time_sql();
+      $stat_time_temp = localtime();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
-    }
-
-    my @t_sql_custom_columns_statistics = ();
-
-    if (@sql_custom_columns_statistics) {
-      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
-
-      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
-        $_ = $t_sql_custom_columns_statistics[$i];
-        if ($DEBUGGING >= 1) {
-          print "Performing substitution on custom column: $_\n";
-        }
-        substitute_sql_stat();
-        if ($DEBUGGING >= 1) {
-          print "Done performing substitution on custom column: $_\n";
-        }
-        $t_sql_custom_columns_statistics[$i] = $_;
-      }
+      $stat_time_temp = strftime $stat_time_format_sql, localtime();
     }
 
     if ($unknown_trap_nodes_match_mode != 0) {
@@ -6281,8 +6172,7 @@ sub log_statistics {
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
         "total_skipped", $g_total_traps_skipped,
-        "total_unknown", $g_total_traps_unknown,
-        @t_sql_custom_columns_statistics);
+        "total_unknown", $g_total_traps_unknown);
     }
     else {
         postgresql_insert($postgresql_dbi_table_statistics,
@@ -6290,8 +6180,7 @@ sub log_statistics {
         "total_received", $g_total_traps_received,
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
-        "total_unknown", $g_total_traps_unknown,
-        @t_sql_custom_columns_statistics);
+        "total_unknown", $g_total_traps_unknown);
     }
   }
 
@@ -6300,28 +6189,10 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = get_time_sql();
+      $stat_time_temp = localtime();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
-    }
-
-    my @t_sql_custom_columns_statistics = ();
-
-    if (@sql_custom_columns_statistics) {
-      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
-
-      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
-        $_ = $t_sql_custom_columns_statistics[$i];
-        if ($DEBUGGING >= 1) {
-          print "Performing substitution on custom column: $_\n";
-        }
-        substitute_sql_stat();
-        if ($DEBUGGING >= 1) {
-          print "Done performing substitution on custom column: $_\n";
-        }
-        $t_sql_custom_columns_statistics[$i] = $_;
-      }
+      $stat_time_temp = strftime $stat_time_format_sql, localtime();
     }
 
     if ($unknown_trap_nodes_match_mode != 0) {
@@ -6331,8 +6202,7 @@ sub log_statistics {
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
         "total_skipped", $g_total_traps_skipped,
-        "total_unknown", $g_total_traps_unknown,
-        @t_sql_custom_columns_statistics);
+        "total_unknown", $g_total_traps_unknown);
     }
     else {
         odbc_insert($dbd_odbc_table_statistics,
@@ -6340,8 +6210,7 @@ sub log_statistics {
         "total_received", $g_total_traps_received,
         "total_translated", $g_total_traps_translated,
         "total_ignored", $g_total_traps_ignored,
-        "total_unknown", $g_total_traps_unknown,
-        @t_sql_custom_columns_statistics);
+        "total_unknown", $g_total_traps_unknown);
     }
   }
 
@@ -6350,30 +6219,12 @@ sub log_statistics {
     my $stat_time_temp;
 
     if ($stat_time_format_sql eq "") {
-      $stat_time_temp = get_time_sql();
+      $stat_time_temp = localtime();
     }
     else {
-      $stat_time_temp = strftime $stat_time_format_sql, get_time_sql();
+      $stat_time_temp = strftime $stat_time_format_sql, localtime();
     }
-
-    my @t_sql_custom_columns_statistics = ();
-
-    if (@sql_custom_columns_statistics) {
-      @t_sql_custom_columns_statistics = @sql_custom_columns_statistics;
-
-      for (my $i = 1; $i <= $#t_sql_custom_columns_statistics; $i+=2) {
-        $_ = $t_sql_custom_columns_statistics[$i];
-        if ($DEBUGGING >= 1) {
-          print "Performing substitution on custom column: $_\n";
-        }
-        substitute_sql_stat();
-        if ($DEBUGGING >= 1) {
-          print "Done performing substitution on custom column: $_\n";
-        }
-        $t_sql_custom_columns_statistics[$i] = $_;
-      }
-    }
-
+    
     if ($unknown_trap_nodes_match_mode != 0) {
       sql_win32_odbc_insert($sql_win32_odbc_table_statistics,
       "stat_time", $stat_time_temp,
@@ -6381,8 +6232,7 @@ sub log_statistics {
       "total_translated", $g_total_traps_translated,
       "total_ignored", $g_total_traps_ignored,
       "total_skipped", $g_total_traps_skipped,
-      "total_unknown", $g_total_traps_unknown,
-      @t_sql_custom_columns_statistics);
+      "total_unknown", $g_total_traps_unknown);
     }
     else {
       sql_win32_odbc_insert($sql_win32_odbc_table_statistics,
@@ -6390,8 +6240,7 @@ sub log_statistics {
       "total_received", $g_total_traps_received,
       "total_translated", $g_total_traps_translated,
       "total_ignored", $g_total_traps_ignored,
-      "total_unknown", $g_total_traps_unknown,
-      @t_sql_custom_columns_statistics);
+      "total_unknown", $g_total_traps_unknown);
     }
   }
 
@@ -7002,47 +6851,26 @@ sub sql_win32_odbc_insert {
   #print "sql_statement: $sql_statement\n";
    
   if (defined ($dbh_win32_odbc)) {
-    my $dbh_win32_odbc_retries = 3;
-    while ($dbh_win32_odbc_retries) {
-      if (defined ($dbh_win32_odbc->Sql($sql_statement))) # Error
+    if (defined ($dbh_win32_odbc->Sql($sql_statement)))
+    {
+      my $msg = "Win32::ODBC error: Unable to perform INSERT INTO: ".Win32::ODBC::Error();
+      warn $msg, "\n";
+
+      if ($DEBUGGING >= 1)
       {
-        my $msg = "Win32::ODBC error: Unable to perform INSERT INTO: ".Win32::ODBC::Error();
-        warn $msg, "\n";
-
-        if ($DEBUGGING >= 1)
-        {
-          print $msg, "\n";
-        }
-
-        if ($eventlog_system_enable == 1)
-        {
-          eventlog_system($msg,17,$eventlog_error);
-        }
-        
-        $msg = "Attempting to re-open Win32::ODBC connection";
-        warn $msg, "\n";
-
-        if ($DEBUGGING >= 1)
-        {
-          print $msg, "\n";
-        }
-
-        if ($eventlog_system_enable == 1)
-        {
-          eventlog_system($msg,17,$eventlog_error);
-        }
-
-        dbh_win32_odbc_close();
-        dbh_win32_odbc_connect();
-        
-        $dbh_win32_odbc_retries--;
-        sleep 0.1;
+        print $msg, "\n";
       }
-      else { # No error
-        return 1;
+
+      if ($eventlog_system_enable == 1)
+      {
+        eventlog_system($msg,17,$eventlog_error);
       }
     }
-    return 0;
+    else
+    {
+      return 1;
+    }
+  return 0;
   }
 }
 
@@ -7092,55 +6920,54 @@ sub preexec_run {
         print "\n\nPREEXEC line(s):\n";
       }
 
-      if (defined ($event2[9][0]))
+      if (defined ($event2[9][0])) # if PREEXEC string has been defined
       {
-        #print "PREEXEC defined\n";
-        for (my $i=0; defined($event2[9][$i]); $i++)
+        print "PREEXEC defined\n";
+        if (defined ($event2[9][0]))
         {
-          $_ = $event2[9][$i];
-
-          if ($DEBUGGING >= 1) {
-            print "Performing substitution on PREEXEC line: $_\n";
-          }
-          substitute();
-          if ($DEBUGGING >= 1) {
-            print "Done performing substitution on PREEXEC line: $_\n";
-          }
-
-          my $command = $_;
-
-          if ($pre_exec_enable == 1)
+          for (my $i=0; defined($event2[9][$i]); $i++)
           {
-            if ($DEBUGGING >= 1)
+            $_ = $event2[9][$i];
+
+            print "Performing substitution on PREEXEC line: $_\n";
+            substitute();
+            print "Done performing substitution on PREEXEC line: $_\n";
+
+            my $command = $_;
+
+            if ($pre_exec_enable == 1)
             {
-              print "PREEXEC command: $command\n";
-            }
-            # Execute command
+              if ($DEBUGGING >= 1)
+              {
+                print "PREEXEC command: $command\n";
+              }
+              # Execute command
 
-            if ($exec_escape == 1) {
-              # Escape wildcard characters
-              $command =~ s/\*/\\\*/g;
-              $command =~ s/\?/\\\?/g;
-            }
-            my $result = `$command`;
-            chomp $result;
-            # Remove spaces before and after
-            $result =~ /^\s*(.*?)\s*$/;
-            $result = $1;
+              if ($exec_escape == 1) {
+                # Escape wildcard characters
+                $command =~ s/\*/\\\*/g;
+                $command =~ s/\?/\\\?/g;
+              }
+              my $result = `$command`;
+              chomp $result;
+              # Remove spaces before and after
+              $result =~ /^\s*(.*?)\s*$/;
+              $result = $1;
 
-            if ($result eq '') {
-              $result = "(no output from PREEXEC)\n";
+              if ($result eq '') {
+                $result = "(no output from PREEXEC)\n";
+              }
+              print "        command output: $result\n";
+              push (@preexec_var, $result);
             }
-            print "        command output: $result\n";
-            push (@preexec_var, $result);
           }
         }
-      }
-      else
-      {
-        if ($DEBUGGING >= 1)
+        else
         {
-          print "  PREEXEC line not defined\n";
+          if ($DEBUGGING >= 1)
+          {
+            print "  PREEXEC line not defined\n";
+          }
         }
       }
 }
@@ -7191,21 +7018,6 @@ sub ip_to_name {
             $hostname = undef;
         }
     }
-
-    if ($hostname) {
-      if ($dns_normalise_case == 1) {
-        $hostname = lc $hostname;
-        if ($DEBUGGING >= 2) {
-          print "  Host name changed to lower case: $hostname\n\n";
-        }
-      }
-      elsif ($dns_normalise_case == 2) {
-        $hostname = uc $hostname;
-        if ($DEBUGGING >= 2) {
-          print "  Host name changed to upper case: $hostname\n\n";
-        }
-      }
-    }
     return $hostname;
 }
 
@@ -7242,45 +7054,3 @@ sub name_to_ip {
     return @ips;
 }
 
-
-sub get_time {
-  my $t_time = shift;
-
-  if (!defined($t_time)) {
-    if ($date_time_utc == 1) {
-        return gmtime();
-    }
-    else {
-        return localtime();
-    }
-  }
-  else {
-    if ($date_time_utc == 1) {
-        return gmtime($t_time);
-    }
-    else {
-        return localtime($t_time);
-    }
-  }
-}
-
-sub get_time_sql {
-  my $t_time = shift;
-
-  if (!defined($t_time)) {
-    if ($date_time_utc_sql == 1) {
-        return gmtime();
-    }
-    else {
-        return localtime();
-    }
-  }
-  else {
-    if ($date_time_utc_sql == 1) {
-        return gmtime($t_time);
-    }
-    else {
-        return localtime($t_time);
-    }
-  }
-}


### PR DESCRIPTION
This is essentially completing the fix originally found in: https://sourceforge.net/p/snmptt/bugs/40/

File locking was added to spool files in snmptt v1.5 when processed by snmptthandler or snmpttthandler-embedded.  This locking using flock or fcntl was not added to the main snmptt program. 

File locking on Linux is advisory in nature rather than explicit in Windows.  On Linux hosts with file locking support, the subsequent read operation by snmptt on a spool file was not obeying the file lock and appears to have been allowing snmptt to read spool files that were not totally written when a large number of traps occurred.   This occurred because snmptt itself did not check for the file lock before ingesting the spool file. 

This update ports the code from snmptthandler-embedded into snmptt and attempts to acquire a shared lock on each spool file.  Should it be unable to acquire the lock (because the handler is still writing it), it will loop every 200ms waiting for the lock to become available until it reaches a set timeout (default 5s).  Should timeout be reached, the attempt is logged and the file is read as-is.